### PR TITLE
any control vector compatiblity

### DIFF
--- a/kinfer_evals/core/eval_engine.py
+++ b/kinfer_evals/core/eval_engine.py
@@ -15,7 +15,7 @@ from kmv.utils.logging import VideoWriter
 
 from kinfer_evals.core import metrics
 from kinfer_evals.core.eval_types import PrecomputedInputState, RunArgs
-from kinfer_evals.core.eval_utils import load_sim_and_runner
+from kinfer_evals.core.eval_utils import get_num_model_commands, load_sim_and_runner
 from kinfer_evals.core.recorder import Recorder
 from kinfer_evals.publishers.notion import push_summary
 
@@ -128,17 +128,19 @@ async def run_eval(
     • wrap it in PrecomputedInputState
     • run the episode & save artifacts
     """
+    num_model_commands = get_num_model_commands(args.kinfer)
+
     sim, runner, provider = await load_sim_and_runner(
         args.kinfer,
         args.robot,
-        cmd_factory=lambda: PrecomputedInputState([[0.0, 0.0, 0.0]]),
+        cmd_factory=lambda: PrecomputedInputState([[0.0] * num_model_commands]),
         render=args.render,
         free_camera=False,
     )
 
     freq = sim._control_frequency
     commands = make_cmds(freq)
-    provider.keyboard_state = PrecomputedInputState(commands)
+    provider.keyboard_state = PrecomputedInputState(commands, num_model_commands)
     duration_seconds = len(commands) / freq
 
     # Create timestamped subdirectory for this run

--- a/kinfer_evals/core/eval_types.py
+++ b/kinfer_evals/core/eval_types.py
@@ -25,10 +25,20 @@ class CommandFactory(Protocol):
 class PrecomputedInputState(InputState):
     """InputState that walks through a pre-computed command list."""
 
-    def __init__(self, commands: list[list[float]]) -> None:
+    def __init__(self, commands: list[list[float]], num_model_commands: int | None = None) -> None:
         self._cmds = commands
         self._idx = 0
-        self.value = self._cmds[0]
+        self._value = self._cmds[0]
+        self.model_num_commands = num_model_commands if num_model_commands is not None else len(self._value)
+
+    @property
+    def value(self) -> list[float]:
+        """Return a full ControlVectorInputState, truncated to the model's command length."""
+        return self._value[:self.model_num_commands]
+
+    @value.setter
+    def value(self, value: list[float]) -> None:
+        self._value = value
 
     async def update(self, _key: str) -> None:  # not used here
         pass


### PR DESCRIPTION
adds compatibility with any size control vector up to 16, instead of assuming all models are 3. 

will auto truncate the control vector up to the length specified by the ml person in metadata.